### PR TITLE
Replicate steam install script behaviour

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 ordered-set
 flake8
 cx-Freeze
+vdf

--- a/scripts/extract_version.py
+++ b/scripts/extract_version.py
@@ -4,7 +4,7 @@ import os
 
 from pathlib import Path
 
-from src.utils import get_exe_name, get_game_version
+from src.utils.utils import get_exe_name, get_game_version
 
 
 def main():

--- a/src/app.py
+++ b/src/app.py
@@ -11,7 +11,7 @@ import tkinter.messagebox
 
 import redirector
 from logic import Logic
-from utils import base_path
+from utils.path_utils import get_base_path
 
 
 class App():
@@ -32,7 +32,7 @@ class App():
             self.logic.cancel_downloads()
 
             # Log text box content to file
-            with open(base_path() / "log.txt", "w+") as file:
+            with open(get_base_path() / "log.txt", "w+") as file:
                 file.write(self.text_box.get(1.0, "end-1c"))
 
             self.window.destroy()

--- a/src/depot_downloader_helper.py
+++ b/src/depot_downloader_helper.py
@@ -9,7 +9,7 @@ import time
 import tkinter
 import tkinter.simpledialog
 
-import utils
+import utils.path_utils as path_utils
 
 
 class ProcessState(Enum):
@@ -35,7 +35,7 @@ class DepotDownloaderHelper:
         Raises:
             ConnectionError: If there was an error during authentication
         """
-        args = ["dotnet", str(utils.get_tools_path('DepotDownloader/DepotDownloader.dll').absolute())] + options
+        args = ["dotnet", str(path_utils.get_tools_path('DepotDownloader/DepotDownloader.dll').absolute())] + options
 
         # Spawn process and store in queue
         process = subprocess.Popen(

--- a/src/depot_downloader_helper.py
+++ b/src/depot_downloader_helper.py
@@ -35,7 +35,7 @@ class DepotDownloaderHelper:
         Raises:
             ConnectionError: If there was an error during authentication
         """
-        args = ["dotnet", str(utils.tools_path('DepotDownloader/DepotDownloader.dll').absolute())] + options
+        args = ["dotnet", str(utils.get_tools_path('DepotDownloader/DepotDownloader.dll').absolute())] + options
 
         # Spawn process and store in queue
         process = subprocess.Popen(

--- a/src/logic.py
+++ b/src/logic.py
@@ -9,6 +9,7 @@ import manifest
 import utils.utils as utils
 import utils.path_utils as path_utils
 import utils.file_utils as file_utils
+import utils.vdf_utils as vdf_utils
 
 
 class Logic:
@@ -44,22 +45,22 @@ class Logic:
                 raise Exception("The selected version is already installed")
 
             print("Starting download phase...")
-
             self._download_patch(username, installed_version, target_version)
-
             print("Finished downloading files")
 
             print("Starting backup...")
-
             self._backup()
-
             print("Finished backup")
 
             print("Patching files...")
-
             self._move_patch()
-
             print("Finished patching files")
+
+            # For windows we want to trigger steam installation script on next run
+            if (utils.is_windows_platform()):
+                print("Resetting installation state...")
+                self._flag_for_install()
+                print("Finished resetting installation state")
         except Exception:
             raise
 
@@ -91,6 +92,12 @@ class Logic:
                 raise Exception("Error restoring files!")
         except Exception:
             raise Exception("Error removing files!")
+
+        # For windows we want to trigger steam installation script on next run
+        if (utils.is_windows_platform()):
+            print("Resetting installation state...")
+            self._flag_for_install()
+            print("Finished resetting installation state")
 
     def set_game_dir(self, dir: Path) -> None:
         """Tries to set the game directory, if successful return True. Otherwise return False.
@@ -350,3 +357,24 @@ class Logic:
         current_manifest = manifest.read_manifest(self.manifest_dir / f"manifest_{depot_id}_{manifest_id}.txt")
 
         return current_manifest.files
+
+    def _flag_for_install(self) -> None:
+        """Flag the game installation to run the install script on next launch.
+        """
+        # Find vdf file
+        vdf_files = file_utils.find_files(self.game_dir, "*.vdf")
+
+        if not vdf_files:
+            raise Exception("Could not find install script")
+
+        if len(vdf_files) > 1:
+            print("Warning: Found more than one install script. Picking first one.")
+
+        # Parse vdf file
+        install_script_file = vdf_files[0]
+        install_script = vdf_utils.parse(install_script_file)
+        has_run_keys = vdf_utils.find_has_run_keys(install_script)
+
+        # Reset all found registry keys
+        for value_name, registry_path in has_run_keys:
+            utils.delete_registry_value(registry_path, value_name)

--- a/src/logic.py
+++ b/src/logic.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import shutil
 import tempfile
 from pathlib import Path
@@ -7,7 +6,9 @@ from pathlib import Path
 from depot_downloader_helper import DepotDownloaderHelper
 from web_helper import WebHelper
 import manifest
-import utils
+import utils.utils as utils
+import utils.path_utils as path_utils
+import utils.file_utils as file_utils
 
 
 class Logic:
@@ -17,9 +18,9 @@ class Logic:
         self.webhook = WebHelper()
         # The earliest patch that works was released after direct x update
         # @TODO Try to figure out a way to patch to earlier patches than this: time.struct_time((2020, 2, 17, 0, 0, 0, 0, 48, 0))
-        self.download_dir = utils.base_path() / "download"
-        self.manifest_dir = utils.base_path() / "manifests"
-        self.backup_dir = utils.base_path() / "backup"
+        self.download_dir = path_utils.get_base_path() / "download"
+        self.manifest_dir = path_utils.get_base_path() / "manifests"
+        self.backup_dir = path_utils.get_base_path() / "backup"
         self.patch_list = self.webhook.query_patches()
         self.depot_downloader_helper = DepotDownloaderHelper()
 
@@ -78,7 +79,7 @@ class Logic:
         # Remove added files from the path
         try:
             print("Removing patched files...")
-            utils.remove_patched_files(self.game_dir, self.download_dir, True)
+            file_utils.remove_patched_files(self.game_dir, self.download_dir, True)
             print("Finished removing patched files")
 
             # Copy backed up files to game path again
@@ -129,7 +130,7 @@ class Logic:
             target_version (int): The target version
         """
         # dotnet is required to proceed
-        if not (utils.check_dotnet()):
+        if not (utils.is_dotnet_available()):
             raise Exception("DOTNET Core required but not found!")
 
         update_list = []
@@ -233,7 +234,7 @@ class Logic:
                     raise Exception("Error removing previous backup directory")
             self.backup_dir.mkdir()
 
-            utils.backup_files(self.game_dir, self.download_dir, self.backup_dir, True)
+            file_utils.backup_files(self.game_dir, self.download_dir, self.backup_dir, True)
         except Exception:
             raise
 

--- a/src/logic.py
+++ b/src/logic.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import shutil
 import tempfile
+from pathlib import Path
 
 from depot_downloader_helper import DepotDownloaderHelper
 from web_helper import WebHelper
@@ -30,7 +31,7 @@ class Logic:
             target_version (int): The version to patch to
         """
         try:
-            # Check some stuff
+            # Check some stuff prerequisites
             if not hasattr(self, "game_dir") or self.game_dir is None:
                 raise Exception("Please select a game directory")
 
@@ -90,11 +91,11 @@ class Logic:
         except Exception:
             raise Exception("Error removing files!")
 
-    def set_game_dir(self, dir: pathlib.Path) -> None:
+    def set_game_dir(self, dir: Path) -> None:
         """Tries to set the game directory, if successful return True. Otherwise return False.
 
         Args:
-            dir (pathlib.Path): The directory to be set
+            dir (Path): The directory to be set
         """
         aoe_binary = dir / "AoE2DE_s.exe"
 
@@ -175,29 +176,30 @@ class Logic:
         for current_depot, target_depot in zip(current_patch["depots"], target_patch["depots"]):
             # Check if depot id changes (VCRedist for example does change sometimes)
             # (Temporary?) solution just skip non-matching depot since old depots are no longer available and hope it still works
-            if current_depot["depot_id"] == target_depot["depot_id"]:
-                depot_id = current_depot["depot_id"]
-                current_manifest_id = current_depot["manifest_id"]
-                target_manifest_id = target_depot["manifest_id"]
-
-                changes = self._get_filelist(username, depot_id, current_manifest_id, target_manifest_id)
-
-                # Files have changed, store changes to temp file and add to update list
-                if changes is not None:
-                    # Create temp file
-                    tmp = tempfile.NamedTemporaryFile(mode="w", delete=False)
-
-                    # Store file name for deletion later on
-                    tmp_files.append(tmp.name)
-
-                    # Write content to file
-                    tmp.write("\n".join(changes))
-                    tmp.close()
-
-                    # Add update element to list
-                    update_list.append({'depot_id': depot_id, 'manifest_id': target_manifest_id, 'filelist': tmp.name})
-            else:
+            if current_depot["depot_id"] != target_depot["depot_id"]:
                 print(f"Depot ID not matching, discarding pair ({current_depot['depot_id']}, {target_depot['depot_id']})")
+                continue
+
+            depot_id = current_depot["depot_id"]
+            current_manifest_id = current_depot["manifest_id"]
+            target_manifest_id = target_depot["manifest_id"]
+
+            changes = self._get_filelist(username, depot_id, current_manifest_id, target_manifest_id)
+
+            # Files have changed, store changes to temp file and add to update list
+            if changes is not None:
+                # Create temp file
+                tmp = tempfile.NamedTemporaryFile(mode="w", delete=False)
+
+                # Store file name for deletion later on
+                tmp_files.append(tmp.name)
+
+                # Write content to file
+                tmp.write("\n".join(changes))
+                tmp.close()
+
+                # Add update element to list
+                update_list.append({'depot_id': depot_id, 'manifest_id': target_manifest_id, 'filelist': tmp.name})
 
         print("Downloading files")
 
@@ -294,8 +296,8 @@ class Logic:
         if current_manifest_id == target_manifest_id:
             return None
 
-        removed = []
-        modified = []
+        removed_names = []
+        modified_names = []
 
         # Download manifests
         self._download_manifest(username, depot_id, current_manifest_id)
@@ -318,19 +320,18 @@ class Logic:
         diff_added_names = set([x[0] for x in diff_added])
 
         # Find all removed files (Remove files with same name but different hash)
-        removed = set.difference(diff_removed_names, diff_added_names)
+        removed_names = set.difference(diff_removed_names, diff_added_names)
 
         # Find all modified files (Retain files with same name but different hash)
-        modified = set.intersection(diff_removed_names, diff_added_names)
+        modified_names = set.intersection(diff_removed_names, diff_added_names)
 
         changes = []
-
-        changes += removed
-        changes += modified
+        changes += removed_names
+        changes += modified_names
 
         return changes
 
-    def _get_filelist_current(self, username: str, password: str, depot_id: int, manifest_id: int) -> list[str]:
+    def _get_filelist_current(self, username: str, depot_id: int, manifest_id: int) -> list[str]:
         """Get a list of all files current files of a depot.
 
         Args:

--- a/src/redirector.py
+++ b/src/redirector.py
@@ -1,4 +1,4 @@
-import utils
+import utils.utils as utils
 
 
 class IORedirector(object):

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,8 +1,8 @@
 import sys
 import os
-import pathlib
 import shutil
 import pefile
+from pathlib import Path
 
 from tkinter import Text
 
@@ -11,11 +11,11 @@ def get_exe_name() -> str:
     return "AoE2DE_s.exe"
 
 
-def get_binary_version(path: pathlib.Path) -> tuple[int, int, int, int]:
+def get_binary_version(path: Path) -> tuple[int, int, int, int]:
     """Retrieve the version number of a binary file.
 
     Args:
-        path (pathlib.Path): The path to the file
+        path (Path): The path to the file
 
     Returns:
         tuple: Windows version number
@@ -40,7 +40,7 @@ def get_binary_version(path: pathlib.Path) -> tuple[int, int, int, int]:
         return version_number
 
 
-def get_game_version(game_dir: pathlib.Path) -> int:
+def get_game_version(game_dir: Path) -> int:
     """Retrieve the game version from the executable file.
 
     Returns:
@@ -64,12 +64,12 @@ def log(text_widget: Text, text: str) -> None:
     text_widget.see("end")
 
 
-def copy_file_or_dir(source_dir: pathlib.Path, target_dir: pathlib.Path, file: str) -> None:
+def copy_file_or_dir(source_dir: Path, target_dir: Path, file: str) -> None:
     """Copies a file or a directory recursively into the target directory.
 
     Args:
-        source_dir (pathlib.Path): The source directory
-        target_dir (pathlib.Path): The target directory
+        source_dir (Path): The source directory
+        target_dir (Path): The target directory
         file (str): The file or directory name
     """
     if (source_dir / file).is_dir():
@@ -78,11 +78,11 @@ def copy_file_or_dir(source_dir: pathlib.Path, target_dir: pathlib.Path, file: s
         shutil.copy((source_dir / file).absolute(), (target_dir / file).absolute())
 
 
-def remove_file_or_dir(path: pathlib.Path) -> None:
+def remove_file_or_dir(path: Path) -> None:
     """Removes a file or directory recursively. Does not throw an error if file does not exist.
 
     Args:
-        path (pathlib.Path): The path to be removed
+        path (Path): The path to be removed
     """
     if path.is_dir():
         shutil.rmtree(path.absolute(), ignore_errors=True)
@@ -90,13 +90,13 @@ def remove_file_or_dir(path: pathlib.Path) -> None:
         path.unlink(missing_ok=True)
 
 
-def backup_files(original_dir: pathlib.Path, override_dir: pathlib.Path, backup_dir: pathlib.Path, debug_info: bool) -> None:
+def backup_files(original_dir: Path, override_dir: Path, backup_dir: Path, debug_info: bool) -> None:
     """Recursively performs backup of original_dir to backup_dir assuming all files/folder from override_dir will be patched.
 
     Args:
-        original_dir (pathlib.Path): The original directory
-        override_dir (pathlib.Path): The directory containing files / directories that will be overridden
-        backup_dir (pathlib.Path): The directory where the backup will be placed
+        original_dir (Path): The original directory
+        override_dir (Path): The directory containing files / directories that will be overridden
+        backup_dir (Path): The directory where the backup will be placed
         debug_info (bool): Flag for printing debug info
     """
     changed_file_list = list(set(os.listdir(original_dir.absolute())).intersection(set(os.listdir(override_dir.absolute()))))
@@ -114,12 +114,12 @@ def backup_files(original_dir: pathlib.Path, override_dir: pathlib.Path, backup_
             copy_file_or_dir(original_dir, backup_dir, file)
 
 
-def remove_patched_files(original_dir: pathlib.Path, override_dir: pathlib.Path, debug_info: bool) -> None:
+def remove_patched_files(original_dir: Path, override_dir: Path, debug_info: bool) -> None:
     """Recursively removes all patched files assuming original_dir has been patched with all files from override_dir.
 
     Args:
-        original_dir (pathlib.Path): The original directory
-        override_dir (pathlib.Path): The directory containing the files that have been overridden
+        original_dir (Path): The original directory
+        override_dir (Path): The directory containing the files that have been overridden
         debug_info (bool): Flag for printing debug info
 
     Raises:
@@ -159,44 +159,44 @@ def check_dotnet() -> bool:
     return not (shutil.which("dotnet") is None)
 
 
-def base_path() -> pathlib.Path:
+def base_path() -> Path:
     """Construct the base path to the exe / project.
 
     Returns:
-        pathlib.Path: The base path of the executable or project
+        Path: The base path of the executable or project
     """
     # Check for pyinstaller
     if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-        return pathlib.Path(sys._MEIPASS)
+        return Path(getattr(sys, '_MEIPASS'))
 
     # Check for cx_Freeze
     if getattr(sys, 'frozen', False) and sys.platform == 'win32':
         # On Windows, the executable is in the root directory
-        return pathlib.Path(sys.executable).parent
+        return Path(sys.executable).parent
 
     if getattr(sys, 'frozen', False):
         # On Unix-like systems, check for common cx_Freeze structures
-        base = pathlib.Path(sys.executable).parent
+        base = Path(sys.executable).parent
         if (base / 'lib').exists():
             return base
         return base
 
     # Check for nuitka
     if "__compiled__" in globals() or hasattr(sys, 'nuitka_version_info'):
-        return pathlib.Path(sys.executable).parent
+        return Path(sys.executable).parent
 
     # Running as script (expects to be inside root/src)
-    return pathlib.Path(__file__).parent.parent
+    return Path(__file__).parent.parent
 
 
-def tools_path(relative_path: str) -> pathlib.Path:
+def get_tools_path(relative_path: str) -> Path:
     """Construct the path for a tool.
 
     Args:
         relative_path (str): The path relative to the tools path
 
     Returns:
-        pathlib.Path: The path to the given tool
+        Path: The path to the given tool
     """
     return base_path() / "tools" / relative_path
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+"""utils package."""

--- a/src/utils/file_utils.py
+++ b/src/utils/file_utils.py
@@ -1,67 +1,6 @@
-import sys
 import os
 import shutil
-import pefile
 from pathlib import Path
-
-from tkinter import Text
-
-
-def get_exe_name() -> str:
-    return "AoE2DE_s.exe"
-
-
-def get_binary_version(path: Path) -> tuple[int, int, int, int]:
-    """Retrieve the version number of a binary file.
-
-    Args:
-        path (Path): The path to the file
-
-    Returns:
-        tuple: Windows version number
-    """
-    # Untested under linux, but I would assume it works..
-    # TODO: Test
-    with pefile.PE(path, fast_load=True) as pe:
-        pe.parse_data_directories(directories=[pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_RESOURCE"]])
-
-        if not hasattr(pe, "VS_FIXEDFILEINFO") or not pe.VS_FIXEDFILEINFO:
-            raise ValueError("Could not find VS_FIXEDFILEINFO in binary")
-
-        file_info = pe.VS_FIXEDFILEINFO[0]
-
-        version_number = (
-            file_info.FileVersionMS >> 16,
-            file_info.FileVersionMS & 0xFFFF,
-            file_info.FileVersionLS >> 16,
-            file_info.FileVersionLS & 0xFFFF
-        )
-
-        return version_number
-
-
-def get_game_version(game_dir: Path) -> int:
-    """Retrieve the game version from the executable file.
-
-    Returns:
-        int: The detected game version
-    """
-    metadata = get_binary_version(game_dir / get_exe_name())
-
-    return (metadata[1] - 101) * 65536 + metadata[2]
-
-
-def log(text_widget: Text, text: str) -> None:
-    """Logs a given string to the text widget.
-
-    Args:
-        text_widget (Text): The text widget
-        text (str): The text
-    """
-    text_widget.configure(state="normal")
-    text_widget.insert("end", text)
-    text_widget.configure(state="disabled")
-    text_widget.see("end")
 
 
 def copy_file_or_dir(source_dir: Path, target_dir: Path, file: str) -> None:
@@ -88,6 +27,19 @@ def remove_file_or_dir(path: Path) -> None:
         shutil.rmtree(path.absolute(), ignore_errors=True)
     else:
         path.unlink(missing_ok=True)
+
+
+def find_files(path: Path, pattern: str = "*") -> list[Path]:
+    """Finds all files matching the given pattern in a directory.
+
+    Args:
+        path (Path): The directory to scan
+        pattern (str): The pattern to match
+
+    Returns:
+        list[str]: A list of matching files
+    """
+    return [x for x in path.glob(pattern) if x.is_file()]
 
 
 def backup_files(original_dir: Path, override_dir: Path, backup_dir: Path, debug_info: bool) -> None:
@@ -148,60 +100,3 @@ def remove_patched_files(original_dir: Path, override_dir: Path, debug_info: boo
                 remove_file_or_dir(original_dir / file)
     except Exception as e:
         raise e
-
-
-def check_dotnet() -> bool:
-    """Checks if dotnet is available.
-
-    Returns:
-        bool: True if dotnet is available
-    """
-    return not (shutil.which("dotnet") is None)
-
-
-def base_path() -> Path:
-    """Construct the base path to the exe / project.
-
-    Returns:
-        Path: The base path of the executable or project
-    """
-    # Check for pyinstaller
-    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
-        return Path(getattr(sys, '_MEIPASS'))
-
-    # Check for cx_Freeze
-    if getattr(sys, 'frozen', False) and sys.platform == 'win32':
-        # On Windows, the executable is in the root directory
-        return Path(sys.executable).parent
-
-    if getattr(sys, 'frozen', False):
-        # On Unix-like systems, check for common cx_Freeze structures
-        base = Path(sys.executable).parent
-        if (base / 'lib').exists():
-            return base
-        return base
-
-    # Check for nuitka
-    if "__compiled__" in globals() or hasattr(sys, 'nuitka_version_info'):
-        return Path(sys.executable).parent
-
-    # Running as script (expects to be inside root/src)
-    return Path(__file__).parent.parent
-
-
-def get_tools_path(relative_path: str) -> Path:
-    """Construct the path for a tool.
-
-    Args:
-        relative_path (str): The path relative to the tools path
-
-    Returns:
-        Path: The path to the given tool
-    """
-    return base_path() / "tools" / relative_path
-
-
-def clear() -> None:
-    """Clear the screen of the console.
-    """
-    _ = os.system('cls')

--- a/src/utils/path_utils.py
+++ b/src/utils/path_utils.py
@@ -1,0 +1,44 @@
+import sys
+from pathlib import Path
+
+
+def get_base_path() -> Path:
+    """Construct the base path to the exe / project.
+
+    Returns:
+        Path: The base path of the executable or project
+    """
+    # Check for pyinstaller
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        return Path(getattr(sys, '_MEIPASS'))
+
+    # Check for cx_Freeze
+    if getattr(sys, 'frozen', False) and sys.platform == 'win32':
+        # On Windows, the executable is in the root directory
+        return Path(sys.executable).parent
+
+    if getattr(sys, 'frozen', False):
+        # On Unix-like systems, check for common cx_Freeze structures
+        base = Path(sys.executable).parent
+        if (base / 'lib').exists():
+            return base
+        return base
+
+    # Check for nuitka
+    if "__compiled__" in globals() or hasattr(sys, 'nuitka_version_info'):
+        return Path(sys.executable).parent
+
+    # Running as script (expects to be inside root/src/utils)
+    return Path(__file__).parent.parent.parent
+
+
+def get_tools_path(relative_path: str) -> Path:
+    """Construct the path for a tool.
+
+    Args:
+        relative_path (str): The path relative to the tools path
+
+    Returns:
+        Path: The path to the given tool
+    """
+    return get_base_path() / "tools" / relative_path

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -1,0 +1,115 @@
+import sys
+import os
+import shutil
+import pefile
+from pathlib import Path
+
+from tkinter import Text
+
+
+def is_dotnet_available() -> bool:
+    """Checks if dotnet is available.
+
+    Returns:
+        bool: True if dotnet is available
+    """
+    return not (shutil.which("dotnet") is None)
+
+
+def is_windows_platform() -> bool:
+    return sys.platform == "win32"
+
+
+def get_exe_name() -> str:
+    return "AoE2DE_s.exe"
+
+
+def get_binary_version(path: Path) -> tuple[int, int, int, int]:
+    """Retrieve the version number of a binary file.
+
+    Args:
+        path (Path): The path to the file
+
+    Returns:
+        tuple: Windows version number
+    """
+    # Untested under linux, but I would assume it works..
+    # TODO: Test
+    with pefile.PE(path, fast_load=True) as pe:
+        pe.parse_data_directories(directories=[pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_RESOURCE"]])
+
+        if not hasattr(pe, "VS_FIXEDFILEINFO") or not pe.VS_FIXEDFILEINFO:
+            raise ValueError("Could not find VS_FIXEDFILEINFO in binary")
+
+        file_info = pe.VS_FIXEDFILEINFO[0]
+
+        version_number = (
+            file_info.FileVersionMS >> 16,
+            file_info.FileVersionMS & 0xFFFF,
+            file_info.FileVersionLS >> 16,
+            file_info.FileVersionLS & 0xFFFF
+        )
+
+        return version_number
+
+
+def get_game_version(game_dir: Path) -> int:
+    """Retrieve the game version from the executable file.
+
+    Returns:
+        int: The detected game version
+    """
+    metadata = get_binary_version(game_dir / get_exe_name())
+
+    return (metadata[1] - 101) * 65536 + metadata[2]
+
+
+def log(text_widget: Text, text: str) -> None:
+    """Logs a given string to the text widget.
+
+    Args:
+        text_widget (Text): The text widget
+        text (str): The text
+    """
+    text_widget.configure(state="normal")
+    text_widget.insert("end", text)
+    text_widget.configure(state="disabled")
+    text_widget.see("end")
+
+
+def delete_registry_value(registry_path: str, value_name: str) -> None:
+    import winreg
+
+    roots = {
+        "HKEY_LOCAL_MACHINE": winreg.HKEY_LOCAL_MACHINE,
+        "HKEY_CURRENT_USER": winreg.HKEY_CURRENT_USER,
+        "HKEY_CLASSES_ROOT": winreg.HKEY_CLASSES_ROOT,
+        "HKEY_USERS": winreg.HKEY_USERS,
+    }
+
+    root_name, sub_key = registry_path.split("\\", 1)
+
+    try:
+        root = roots[root_name]
+    except KeyError:
+        raise ValueError(
+            f"Unsupported registry root: {root_name}"
+        )
+
+    try:
+        with winreg.OpenKey(
+            root,
+            sub_key,
+            access=winreg.KEY_SET_VALUE | winreg.KEY_WOW64_32KEY,
+        ) as key:
+            winreg.DeleteValue(key, value_name)
+
+    except FileNotFoundError:
+        # Already in the desired state.
+        pass
+
+
+def clear() -> None:
+    """Clear the screen of the console.
+    """
+    _ = os.system('cls')

--- a/src/utils/vdf_utils.py
+++ b/src/utils/vdf_utils.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import vdf
+
+
+def parse(path: Path) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return vdf.load(f)
+
+
+def find_has_run_keys(install_script: dict) -> list[tuple[str, str]]:
+    """Recursively finds all has run registry keys for a given install script.
+
+    Args:
+        install_script (dict): The install script as parsed dictionary
+
+    Returns:
+        list[tuple[str, str]]: A list of (value_name, registry_path) registry keys from the install script
+    """
+    result = []
+
+    def walk(node: dict | list, parent_key: str | None = None):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key == "HasRunKey" and isinstance(value, str):
+                    if parent_key is not None:
+                        result.append((parent_key, value))
+
+                elif isinstance(value, (dict, list)):
+                    walk(value, key)
+
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, parent_key)
+
+    walk(install_script)
+
+    return result


### PR DESCRIPTION
I noticed that steam would trigger an additional install step when verifying game files or updating the game.

This addition is meant to trigger the same behavior, so when the version is patched (or restored) steam will trigger the installation step again.

Originally I thought this might help with #11 however it turns out that is not the case. Anyway, this should still solidify the patching and may help around some issues similar to the mentioned one.

Additionally, there has been a little restructure for the utils library to help clean things up and keep the files a bit smaller.